### PR TITLE
add `index` template function to docs/config/formatting.md

### DIFF
--- a/config/formatting.md
+++ b/config/formatting.md
@@ -36,6 +36,16 @@ include examples of customizing the output format.
 >
 {:.important}
 
+## index
+
+`index` permits special characters in keys.
+
+{% raw %}
+```console
+$ docker inspect --format='{{index . "NetworkSettings" "Networks" "my-network" "IPAddress"}}' container
+```
+{% endraw %}
+
 ## join
 
 `join` concatenates a list of strings to create a single string.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

add `index` template function to docs/config/formatting.md

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
